### PR TITLE
Add chapter sequencing and flashback support

### DIFF
--- a/Assets/Scenes/Chapters/FinalTemple.unity
+++ b/Assets/Scenes/Chapters/FinalTemple.unity
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component: []
+  m_Layer: 0
+  m_Name: FinalTempleRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1

--- a/Assets/Scenes/Chapters/FinalTemple.unity.meta
+++ b/Assets/Scenes/Chapters/FinalTemple.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: abcdefabcdefabcdefabcdefabcdefae
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/Chapters/HauntedForest.unity
+++ b/Assets/Scenes/Chapters/HauntedForest.unity
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component: []
+  m_Layer: 0
+  m_Name: HauntedForestRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1

--- a/Assets/Scenes/Chapters/HauntedForest.unity.meta
+++ b/Assets/Scenes/Chapters/HauntedForest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: abcdefabcdefabcdefabcdefabcdefac
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/Chapters/RitualGrounds.unity
+++ b/Assets/Scenes/Chapters/RitualGrounds.unity
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component: []
+  m_Layer: 0
+  m_Name: RitualGroundsRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1

--- a/Assets/Scenes/Chapters/RitualGrounds.unity.meta
+++ b/Assets/Scenes/Chapters/RitualGrounds.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: abcdefabcdefabcdefabcdefabcdefad
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/Chapters/RuinedHomeTown.unity
+++ b/Assets/Scenes/Chapters/RuinedHomeTown.unity
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component: []
+  m_Layer: 0
+  m_Name: RuinedHomeTownRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1

--- a/Assets/Scenes/Chapters/RuinedHomeTown.unity.meta
+++ b/Assets/Scenes/Chapters/RuinedHomeTown.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: abcdefabcdefabcdefabcdefabcdefab
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Script/Generated/ChapterManager.cs
+++ b/Assets/Script/Generated/ChapterManager.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class ChapterManager : MonoBehaviour
+{
+    [Tooltip("List of chapter scene names in order")]
+    public List<string> chapterScenes = new List<string>
+    {
+        "RuinedHomeTown",
+        "HauntedForest",
+        "RitualGrounds",
+        "FinalTemple"
+    };
+
+    [Tooltip("Name of the player GameObject")] 
+    public string playerObjectName = "Player";
+
+    private int currentChapterIndex = -1;
+    private GameObject player;
+
+    private void Start()
+    {
+        player = GameObject.Find(playerObjectName);
+        LoadNextChapter();
+    }
+
+    public void LoadNextChapter()
+    {
+        currentChapterIndex++;
+        if (currentChapterIndex < chapterScenes.Count)
+        {
+            StartCoroutine(Transition(chapterScenes[currentChapterIndex]));
+        }
+        else
+        {
+            Debug.Log("ChapterManager: No more chapters to load.");
+        }
+    }
+
+    private IEnumerator Transition(string sceneName)
+    {
+        if (player != null)
+        {
+            PlayerPrefs.SetFloat("PlayerX", player.transform.position.x);
+            PlayerPrefs.SetFloat("PlayerY", player.transform.position.y);
+            PlayerPrefs.SetFloat("PlayerZ", player.transform.position.z);
+        }
+
+        yield return SceneManager.UnloadSceneAsync(SceneManager.GetActiveScene().buildIndex);
+        yield return SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
+        SceneManager.SetActiveScene(SceneManager.GetSceneByName(sceneName));
+
+        if (player != null)
+        {
+            player.transform.position = new Vector3(
+                PlayerPrefs.GetFloat("PlayerX"),
+                PlayerPrefs.GetFloat("PlayerY"),
+                PlayerPrefs.GetFloat("PlayerZ"));
+        }
+    }
+}

--- a/Assets/Script/Generated/FlashbackManager.cs
+++ b/Assets/Script/Generated/FlashbackManager.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class FlashbackManager : MonoBehaviour
+{
+    [Tooltip("Name of the player GameObject")]
+    public string playerObjectName = "Player";
+
+    private string previousScene;
+    private GameObject player;
+    private Vector3 savedPosition;
+    private Character savedCharacter;
+
+    public void StartFlashback(string flashbackScene, Character flashbackCharacter, Vector3 startPosition)
+    {
+        StartCoroutine(FlashbackRoutine(flashbackScene, flashbackCharacter, startPosition));
+    }
+
+    private IEnumerator FlashbackRoutine(string flashbackScene, Character flashbackCharacter, Vector3 startPosition)
+    {
+        player = GameObject.Find(playerObjectName);
+        if (player != null)
+        {
+            savedPosition = player.transform.position;
+        }
+        previousScene = SceneManager.GetActiveScene().name;
+        savedCharacter = CharacterManager.Instance.character;
+        CharacterManager.Instance.character = flashbackCharacter;
+
+        yield return SceneManager.LoadSceneAsync(flashbackScene);
+
+        if (player != null)
+        {
+            player = GameObject.Find(playerObjectName);
+            player.transform.position = startPosition;
+        }
+    }
+
+    public void EndFlashback()
+    {
+        StartCoroutine(EndFlashbackRoutine());
+    }
+
+    private IEnumerator EndFlashbackRoutine()
+    {
+        yield return SceneManager.LoadSceneAsync(previousScene);
+        CharacterManager.Instance.character = savedCharacter;
+        if (player == null)
+        {
+            player = GameObject.Find(playerObjectName);
+        }
+        if (player != null)
+        {
+            player.transform.position = savedPosition;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # chatgpt
+
+This repository contains a Unity project used for gameplay testing. It now includes a simple chapter flow managed through scripts.
+
+## New Scenes
+
+The following placeholder scenes have been added under `Assets/Scenes/Chapters`:
+
+- **RuinedHomeTown**
+- **HauntedForest**
+- **RitualGrounds**
+- **FinalTemple**
+
+These scenes are loaded sequentially using the `ChapterManager` component.
+
+## Flashback Support
+
+The `FlashbackManager` script allows temporary scene changes that swap the active `Character` and then return to the previous scene. This enables flashback sequences while preserving player progress.


### PR DESCRIPTION
## Summary
- create placeholder chapter scenes
- add `ChapterManager` for sequential scene loading
- add `FlashbackManager` to swap characters during flashbacks
- document new scenes and flashback feature

## Testing
- `npm test` *(fails: missing package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68409d7df010832b929d41f4616dbf6d